### PR TITLE
Update README to install to user plugins directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,10 @@ Install the provider:
 go get -u github.com/jakexks/terraform-provider-glob
 ```
 
-Edit ~/.terraformrc:
+Copy the provider to the user plugins directory:
 
 ```
-providers {
-  glob = "/bin/terraform-provider-glob" # or /path/to/terraform-provider-glob
-}
+mv ~/go/bin/terraform-provider-glob ~/.terraform.d/plugins # on Windows systems, move to %APPDATA%\terraform.d\plugins instead
 ```
 
 Use the provider:


### PR DESCRIPTION
Heyo. Thank you for the provider.

Documentation fix for something I encountered when using the provider.

---

Specifying providers in terraformrc is depreciated:

https://www.terraform.io/docs/commands/cli-config.html

The recommended method is to copy the provider to the user plugins directory:

https://www.terraform.io/docs/configuration/providers.html#third-party-plugins

This commit updates the README to use the recommended method.